### PR TITLE
Fix wget option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A convenient tool written in Ruby for SSL cipher suites support scanning.
 ##Installation
 ```bash
 user@host $ wget "https://raw.githubusercontent.com/xlucas/ssl-inspector/master/bin/ssl-inspector.rb" \
--o /usr/local/bin/ssl-inspector
+-O /usr/local/bin/ssl-inspector
 user@host $ chmod +x !$
 ```
 


### PR DESCRIPTION
`wget -o <file>` outputs download progress.

```
$ cat /usr/local/bin/ssl-inspector
--2017-07-17 12:09:30--  https://raw.githubusercontent.com/xlucas/ssl-inspector/master/bin/ssl-inspector.rb
Resolving raw.githubusercontent.com... 151.101.40.133, 151.101.0.133, 151.101.64.133, ...
Connecting to raw.githubusercontent.com|151.101.40.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 60513 (59K) [text/plain]
Saving to: ‘ssl-inspector.rb’

     0K .......... .......... .......... .......... .......... 84%  292K 0s
    50K .........                                             100%  222M=0.2s

2017-07-17 12:09:31 (345 KB/s) - ‘ssl-inspector.rb’ saved [60513/60513]
```

`wget -O <file>` specifies the location to save the downloaded file, as expected.