### PR TITLE
Use ruby from $PATH

### DIFF
--- a/bin/ssl-inspector.rb
+++ b/bin/ssl-inspector.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 # ******************************************************************************
 # SSL cipher scanning tool for SSLv3 and TLSv1 TLSv1.1 TLSv1.2


### PR DESCRIPTION
Assuming /usr/bin/ruby for the installation location works on many
systems, but not all. For example, Linux users who install ruby only via
ruby version managers such as rvm, rbenv, and chruby will not
necessarily have a ruby executable located at /usr/bin/ruby.

A shebang using `/usr/bin/env ruby` will be more portable.
See also http://www.brianstorti.com/rethinking-your-shebang/